### PR TITLE
fix(plugin): use functional probe for Playwright MCP detection

### DIFF
--- a/plugins/demofly/commands/create.md
+++ b/plugins/demofly/commands/create.md
@@ -11,9 +11,11 @@ The user invoked `/demofly:create $ARGUMENTS`.
 
 ## Step 0: Check Playwright MCP Availability
 
-Before anything else, verify that Playwright MCP tools are available. Attempt to call `mcp__plugin_playwright_playwright__browser_snapshot` or check your available tools list for any tool starting with `mcp__plugin_playwright_playwright__`.
+Before anything else, verify that Playwright MCP tools are working by **actually calling** `mcp__plugin_playwright_playwright__browser_snapshot`.
 
-**If Playwright MCP tools are NOT available**, tell the user:
+- **If the call succeeds** (returns a snapshot or accessibility tree) → the plugin is working. Continue.
+- **If the call fails with a "no page" or "no browser" type error** → the plugin is working, there is just no page open yet. This is fine. Continue.
+- **If the call fails with a "tool not found" or "unknown tool" error** → the plugin is NOT installed. Tell the user:
 
 > Demofly requires the Playwright MCP plugin. Install it with:
 >
@@ -26,8 +28,12 @@ Before anything else, verify that Playwright MCP tools are available. Attempt to
 > ```
 > /plugin install playwright@anthropics-claude-code
 > ```
+>
+> After installing, **restart Claude Code** (exit and reopen), then re-run `/demofly:create`.
 
 Then **STOP**. Do not continue the pipeline.
+
+**IMPORTANT**: Do NOT just check if the tools appear in your tools list. The only reliable check is to actually call the tool and inspect the error. A "no page open" error means the plugin IS working.
 
 ---
 


### PR DESCRIPTION
## Summary
- The `/demofly:create` command's Step 0 checked if Playwright MCP tools appeared in the available tools list. When the MCP server hasn't initialized yet (e.g. corrupted npx cache, slow startup), the tools don't appear — even though the plugin is installed. This creates an unresolvable loop: "not detected" → "install it" → "already installed."
- Changed Step 0 to actually call `browser_snapshot` and interpret the error type: a "no page open" error means the plugin is working; only a "tool not found" error means it's genuinely missing.
- Added guidance to restart Claude Code after installing, since the MCP server only starts on session init.

## Test plan
- [ ] Install the Playwright plugin, start a new Claude Code session, run `/demofly:create test` — should pass Step 0
- [ ] Uninstall the Playwright plugin, start a new session, run `/demofly:create test` — should show install instructions and stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect Playwright MCP by calling browser_snapshot and interpreting the error, fixing false “not detected” loops in /demofly:create Step 0 and making setup more reliable.

- **Bug Fixes**
  - Replaced tool-list check with a functional probe: call browser_snapshot; treat “no page/browser” as plugin working; only “tool not found/unknown” means missing.
  - Added guidance to restart Claude Code after installing, since the MCP server starts on session init.

<sup>Written for commit b5ae283a2b946261312ad5c03bb0a0aca02acba5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

