### PR TITLE
fix: make narration non-optional in demo pipeline

### DIFF
--- a/plugins/demofly/agents/demo-engineer.md
+++ b/plugins/demofly/agents/demo-engineer.md
@@ -10,7 +10,7 @@ description: >
   "walk through the checkout process on video", "demofly this feature".
 ---
 
-You are the **demo-engineer**, an orchestrator that manages the full lifecycle of automated demo video generation for web applications. You coordinate exploration, narrative design, Playwright script generation, recording, and optional narration.
+You are the **demo-engineer**, an orchestrator that manages the full lifecycle of automated demo video generation for web applications. You coordinate exploration, narrative design, Playwright script generation, recording, and narration.
 
 ## Core Principles
 
@@ -61,7 +61,7 @@ Each demo lives in its own directory under `demofly/`. The pipeline produces the
 | 4 | `demofly/<name>/demo.spec.ts` | Playwright test with `DEMOFLY\|` timing markers in console.log |
 | 5 | `demofly/<name>/playwright.config.ts` | Recording config (viewport, video dir, timeouts) |
 | 6 | `demofly/<name>/recordings/timing.json` | Timing data extracted from DEMOFLY markers in console output |
-| 7 | `demofly/<name>/transcript.md` | Optional narration transcript with TTS tags for audio generation |
+| 7 | `demofly/<name>/transcript.md` | Narration transcript with TTS tags for audio generation |
 
 Reference the `demo-workflow` skill for exact artifact formats and templates.
 
@@ -183,21 +183,21 @@ Return ONLY the corrected JSON, no explanation.
 - An LLM can understand intent and normalize regardless of naming convention
 - This is a two-pass approach: first LLM generates, second LLM validates/fixes
 
-### Phase 7: Narration (Optional)
+### Phase 7: Narration
 
-If the user wants narration, generate `demofly/<name>/transcript.md` with:
+Generate `demofly/<name>/transcript.md` with:
 - Per-beat narration text, organized by beat number matching script.md (e.g., Beat 1.1, Beat 1.2, Beat 2.1).
 - Actual beat timestamps and available time windows from timing.json markers.
 - TTS-compatible tags in bracket format: `[warmly]`, `[confidently]`, `[excited]`, `[pause: 0.5s]`, etc. See the `demo-workflow` skill Section 7 for the full tag reference.
 - Estimated read time vs. available window per beat. Narration should fill 40-70% of each beat's window.
 - Silent beats from script.md are omitted (they produce no audio clip).
 
-### Phase 7: Final Assembly
+### Phase 8: Final Assembly
 
 Delegate TTS and video assembly to the `demofly` CLI:
 
-1. If transcript.md was generated, run `demofly tts <name>` to synthesize audio.
-2. Run `demofly generate <name>` to assemble the final video from existing artifacts.
+1. Run `demofly tts <name>` to synthesize audio from the transcript.
+2. Run `demofly generate <name>` to assemble the final video with narration audio.
 
 The CLI handles all mechanical operations (Kokoro TTS, ffmpeg stitching, format conversion).
 The agent does not run ffmpeg or TTS directly — it delegates to the CLI commands.

--- a/plugins/demofly/commands/create.md
+++ b/plugins/demofly/commands/create.md
@@ -71,7 +71,8 @@ Use `Glob` to check for these files. Then apply this logic:
 | `demofly/<name>/proposal.md` exists but no `script.md` | Script (Step 5) |
 | `demofly/<name>/script.md` exists but no `demo.spec.ts` | Playwright Generation (Step 6) |
 | `demofly/<name>/demo.spec.ts` exists but no `recordings/` with video | Recording (Step 7) |
-| `demofly/<name>/recordings/` contains video but no `recordings/final.mp4` or `recordings/final.webm` | Final Assembly (Step 9) |
+| `demofly/<name>/recordings/` contains video but no `transcript.md` | Narration (Step 8) |
+| `demofly/<name>/transcript.md` exists but no `recordings/final.mp4` or `recordings/final.webm` | Final Assembly (Step 9) |
 | `demofly/<name>/recordings/final.mp4` or `recordings/final.webm` exists | Demo is complete -- ask the user if they want to re-record, add narration, or start fresh |
 
 Tell the user what phase you are starting from and why.
@@ -401,13 +402,11 @@ If ffmpeg is not installed, skip this step and note the video is in `.webm` form
 
 ---
 
-## Step 8: Narration (Optional)
+## Step 8: Narration
 
-After recording succeeds, ask the user: **"Would you like me to generate a narration transcript for this demo?"**
+After recording succeeds, generate the narration transcript.
 
-If **no**, proceed directly to Step 9 (Final Assembly) without TTS.
-
-If **yes**, read `demofly/<name>/script.md` and `demofly/<name>/recordings/timing.json`. Generate `demofly/<name>/transcript.md`:
+Read `demofly/<name>/script.md` and `demofly/<name>/recordings/timing.json`. Generate `demofly/<name>/transcript.md`:
 
 ```markdown
 # Narration Transcript: <name>
@@ -438,7 +437,7 @@ After generating the transcript, proceed to Step 9.
 
 ## Step 9: Final Assembly
 
-**Goal**: Use the `demofly` CLI to generate TTS audio (if narration was requested) and assemble the final video.
+**Goal**: Use the `demofly` CLI to generate TTS audio and assemble the final video with narration.
 
 ### Check demofly CLI availability
 
@@ -465,15 +464,15 @@ If this also fails, or if `demofly` is not found at all, tell the user:
 >
 > Your recording and artifacts are complete — you can run assembly manually later:
 > ```
-> demofly tts <name>        # if narration was generated
-> demofly generate <name>   # assemble final video
+> demofly tts <name>        # generate narration audio
+> demofly generate <name>   # assemble final video with narration
 > ```
 
 Then **STOP** the assembly step. The demo is still usable — the raw video and timing data are in `demofly/<name>/recordings/`.
 
-### Run TTS (if transcript was generated)
+### Run TTS
 
-If `demofly/<name>/transcript.md` was generated in Step 8:
+Generate narration audio from the transcript:
 
 ```bash
 demofly tts <name>

--- a/plugins/demofly/skills/demo-workflow/SKILL.md
+++ b/plugins/demofly/skills/demo-workflow/SKILL.md
@@ -52,7 +52,7 @@ context.md --> proposal.md --> script.md --> demo.spec.ts + playwright.config.ts
 | `demo.spec.ts` | `demofly/<name>/demo.spec.ts` | Executable Playwright test with timing markers, human-like interactions, fake cursor. |
 | `playwright.config.ts` | `demofly/<name>/playwright.config.ts` | Recording configuration. |
 | `timing.json` | `demofly/<name>/recordings/timing.json` | Scene and action timestamps extracted from DEMOFLY markers in console output. |
-| `transcript.md` | `demofly/<name>/transcript.md` | Optional narration with TTS tags and actual durations derived from timing.json. |
+| `transcript.md` | `demofly/<name>/transcript.md` | Narration transcript with TTS tags and actual durations derived from timing.json. |
 
 ### context.md Format
 


### PR DESCRIPTION
## Problem

Narration was marked as optional throughout the plugin instructions (create.md, demo-engineer.md, SKILL.md). This caused agents to skip transcript generation and TTS by default, producing silent demo videos with no voiceover.

Found during end-to-end testing of the demofly pipeline — the sub-agent took "optional" literally and went straight from recording to final assembly without generating narration.

## Changes

- **create.md**: Remove `(Optional)` from Step 8 heading, remove user prompt asking if they want narration, update phase resumption table to include narration as a checkpoint before final assembly
- **demo-engineer.md**: Remove optional labels, fix duplicate Phase 7 numbering (Narration → Phase 7, Final Assembly → Phase 8), update assembly step to assume narration always runs
- **SKILL.md**: Update transcript.md artifact description from "Optional narration" to "Narration transcript"

## Testing

Discovered via OpenClaw sub-agent test harness running the full demofly pipeline against the QuickNotes example app. The agent followed the plugin instructions exactly and skipped narration because it was marked optional.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make narration a required step in the Demofly pipeline to prevent silent videos. The flow now always generates a transcript and TTS before final assembly.

- **Bug Fixes**
  - Removed “(Optional)” and the narration prompt; Step 8 always generates transcript.
  - Added narration checkpoint to the phase resumption table.
  - Fixed phase numbering: Narration = 7, Final Assembly = 8; assembly assumes TTS runs.
  - Updated artifact descriptions to “Narration transcript” (create.md, demo-engineer.md, SKILL.md).

<sup>Written for commit cf71c9c295eae83561107559c7c08155541eda94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

